### PR TITLE
Six (code for py2 and py3)

### DIFF
--- a/bridge/python/test-drive.py
+++ b/bridge/python/test-drive.py
@@ -1,3 +1,7 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+
 import os
 import random
 import string
@@ -10,14 +14,18 @@ def rand_string():
 
 
 # Check that data can flow back & forth across the bridge
-bridge_response = flywheel.test_bridge("world")
-assert bridge_response == "Hello world"
+bridge_response = flywheel.test_bridge('world')
+assert bridge_response == 'Hello world'
 
 # Get API get from environment
 api_key = os.environ['SdkTestKey']
 
 # Create client
 fw = flywheel.Flywheel(api_key)
+
+# A test file
+filepath = __file__
+filename = os.path.basename(filepath)
 
 
 #
@@ -78,14 +86,14 @@ fw.add_project_note(projectId, 'This is a note')
 projects = fw.get_all_projects()
 assert len(projects) > 0
 
-fw.upload_file_to_project(projectId, 'test-drive.py')
-fw.download_file_from_project(projectId, 'test-drive.py', '/tmp/download.py')
+fw.upload_file_to_project(projectId, filepath)
+fw.download_file_from_project(projectId, filename, '/tmp/download.py')
 
 project = fw.get_project(projectId)
 assert project['tags'][0] == 'blue'
 assert project['label'] == 'testdrive'
 assert project['notes'][0]['text'] == 'This is a note'
-assert project['files'][0]['name'] == 'test-drive.py'
+assert project['files'][0]['name'] == filename
 assert project['files'][0]['size'] == os.path.getsize('/tmp/download.py')
 
 
@@ -107,14 +115,14 @@ assert len(sessions) > 0
 sessions = fw.get_all_sessions()
 assert len(sessions) > 0
 
-fw.upload_file_to_session(sessionId, 'test-drive.py')
-fw.download_file_from_session(sessionId, 'test-drive.py', '/tmp/download2.py')
+fw.upload_file_to_session(sessionId, filepath)
+fw.download_file_from_session(sessionId, filename, '/tmp/download2.py')
 
 session = fw.get_session(sessionId)
 assert session['tags'][0] == 'blue'
 assert session['label'] == 'testdrive'
 assert session['notes'][0]['text'] == 'This is a note'
-assert session['files'][0]['name'] == 'test-drive.py'
+assert session['files'][0]['name'] == filename
 assert session['files'][0]['size'] == os.path.getsize('/tmp/download2.py')
 
 
@@ -136,14 +144,14 @@ assert len(acqs) > 0
 acqs = fw.get_all_acquisitions()
 assert len(acqs) > 0
 
-fw.upload_file_to_acquisition(acqId, 'test-drive.py')
-fw.download_file_from_acquisition(acqId, 'test-drive.py', '/tmp/download3.py')
+fw.upload_file_to_acquisition(acqId, filepath)
+fw.download_file_from_acquisition(acqId, filename, '/tmp/download3.py')
 
 acq = fw.get_acquisition(acqId)
 assert acq['tags'][0] == 'blue'
 assert acq['label'] == 'testdrive'
 assert acq['notes'][0]['text'] == 'This is a note'
-assert acq['files'][0]['name'] == 'test-drive.py'
+assert acq['files'][0]['name'] == filename
 assert acq['files'][0]['size'] == os.path.getsize('/tmp/download3.py')
 
 
@@ -165,5 +173,5 @@ fw.delete_session(sessionId)
 fw.delete_project(projectId)
 fw.delete_group(groupId)
 
-print ''
-print 'Test drive complete.'
+print('')
+print('Test drive complete.')

--- a/bridge/templates/template.py
+++ b/bridge/templates/template.py
@@ -5,9 +5,6 @@ import json
 import sys
 import os
 
-if sys.version_info[0] > 2:
-    raise ImportError('flywheel requires Python 2')
-
 # Load the shared object file. Further details are added at the end of the file
 bridge = ctypes.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), '../c/flywheel.so'))
 
@@ -17,9 +14,9 @@ def test_bridge(name):
     Should return "Hello <name>".
     """
 
-    pointer = bridge.TestBridge(name)
+    pointer = bridge.TestBridge(bytes(name, 'utf-8'))
     payload = ctypes.cast(pointer, ctypes.c_char_p).value
-    return payload
+    return payload.decode('utf-8')
 
 class FlywheelException(Exception):
     pass
@@ -33,7 +30,7 @@ class Flywheel:
             raise FlywheelException('Invalid API key.')
 
         self.key = key
-        self.keyC = ctypes.create_string_buffer(key)
+        self.keyC = ctypes.create_string_buffer(bytes(key, 'utf-8'))
 
     @staticmethod
     def _handle_return(status, pointer):
@@ -62,7 +59,7 @@ class Flywheel:
         status = ctypes.c_int(-100)
         {{if ne .ParamDataName ""}}marshalled_{{.ParamDataName}} = json.dumps({{.ParamDataName}})
         {{end}}
-        pointer = bridge.{{.Name}}(self.keyC, {{range .Params}}str({{if eq .Type "data"}}marshalled_{{end}}{{.Name}}), {{end}}ctypes.byref(status))
+        pointer = bridge.{{.Name}}(self.keyC, {{range .Params}}bytes({{if eq .Type "data"}}marshalled_{{end}}{{.Name}}, 'utf-8'), {{end}}ctypes.byref(status))
         return self._handle_return(status, pointer)
     {{end}}
 

--- a/bridge/templates/template.py
+++ b/bridge/templates/template.py
@@ -2,6 +2,7 @@
 
 import ctypes
 import json
+import six
 import sys
 import os
 
@@ -14,7 +15,7 @@ def test_bridge(name):
     Should return "Hello <name>".
     """
 
-    pointer = bridge.TestBridge(bytes(name, 'utf-8'))
+    pointer = bridge.TestBridge(six.b(name))
     payload = ctypes.cast(pointer, ctypes.c_char_p).value
     return payload.decode('utf-8')
 
@@ -30,7 +31,7 @@ class Flywheel:
             raise FlywheelException('Invalid API key.')
 
         self.key = key
-        self.keyC = ctypes.create_string_buffer(bytes(key, 'utf-8'))
+        self.keyC = ctypes.create_string_buffer(six.b(key))
 
     @staticmethod
     def _handle_return(status, pointer):
@@ -59,7 +60,7 @@ class Flywheel:
         status = ctypes.c_int(-100)
         {{if ne .ParamDataName ""}}marshalled_{{.ParamDataName}} = json.dumps({{.ParamDataName}})
         {{end}}
-        pointer = bridge.{{.Name}}(self.keyC, {{range .Params}}bytes({{if eq .Type "data"}}marshalled_{{end}}{{.Name}}, 'utf-8'), {{end}}ctypes.byref(status))
+        pointer = bridge.{{.Name}}(self.keyC, {{range .Params}}six.b(str({{if eq .Type "data"}}marshalled_{{end}}{{.Name}})), {{end}}ctypes.byref(status))
         return self._handle_return(status, pointer)
     {{end}}
 

--- a/bridge/templates/template.py
+++ b/bridge/templates/template.py
@@ -11,98 +11,60 @@ if sys.version_info[0] > 2:
 # Load the shared object file. Further details are added at the end of the file
 bridge = ctypes.cdll.LoadLibrary(os.path.join(os.path.dirname(__file__), '../c/flywheel.so'))
 
-#
-# Begin block to handle unicode in JSON
-# http://stackoverflow.com/a/33571117
-#
-
-def _json_load_byteified(file_handle):
-	return _byteify(
-		json.load(file_handle, object_hook=_byteify),
-		ignore_dicts=True
-	)
-
-def _json_loads_byteified(json_text):
-	return _byteify(
-		json.loads(json_text, object_hook=_byteify),
-		ignore_dicts=True
-	)
-
-def _byteify(data, ignore_dicts = False):
-	# if this is a unicode string, return its string representation
-	if isinstance(data, unicode):
-		return data.encode('utf-8')
-	# if this is a list of values, return list of byteified values
-	if isinstance(data, list):
-		return [ _byteify(item, ignore_dicts=True) for item in data ]
-	# if this is a dictionary, return dictionary of byteified keys and values
-	# but only if we haven't already byteified it
-	if isinstance(data, dict) and not ignore_dicts:
-		return {
-			_byteify(key, ignore_dicts=True): _byteify(value, ignore_dicts=True)
-			for key, value in data.iteritems()
-		}
-	# if it's anything else, return it in its original form
-	return data
-
-#
-# End block to handle unicode in JSON
-#
-
 def test_bridge(name):
-	"""
-	Test if the C bridge is functional.
-	Should return "Hello <name>".
-	"""
+    """
+    Test if the C bridge is functional.
+    Should return "Hello <name>".
+    """
 
-	pointer = bridge.TestBridge(name)
-	payload = ctypes.cast(pointer, ctypes.c_char_p).value
-	return payload
+    pointer = bridge.TestBridge(name)
+    payload = ctypes.cast(pointer, ctypes.c_char_p).value
+    return payload
 
 class FlywheelException(Exception):
-	pass
+    pass
 
 class Flywheel:
 
-	def __init__(self, key):
-		splits = key.split(':')
+    def __init__(self, key):
+        splits = key.split(':')
 
-		if len(splits) < 2:
-			raise FlywheelException('Invalid API key.')
+        if len(splits) < 2:
+            raise FlywheelException('Invalid API key.')
 
-		self.key = key
-		self.keyC = ctypes.create_string_buffer(key)
+        self.key = key
+        self.keyC = ctypes.create_string_buffer(key)
 
-	@staticmethod
-	def _handle_return(status, pointer):
-		statusCode = status.value
-		payload = ctypes.cast(pointer, ctypes.c_char_p).value
+    @staticmethod
+    def _handle_return(status, pointer):
+        statusCode = status.value
+        payload = ctypes.cast(pointer, ctypes.c_char_p).value
 
-		if statusCode == 0 and payload is None:
-			return None
-		elif statusCode == 0:
-			return _json_loads_byteified(payload)['data']
-		else:
-			result = 'Unknown error (status ' + str(statusCode) + ')'
-			try:
-				result = _json_loads_byteified(payload)['message']
-			except:
-				pass
+        if statusCode == 0 and payload is None:
+            return None
+        elif statusCode == 0:
+            return json.loads(payload)['data']
+        else:
+            result = 'Unknown error (status ' + str(statusCode) + ')'
+            try:
+                result = json.loads(payload)['message']
+            except:
+                pass
 
-			raise FlywheelException(result)
+            raise FlywheelException(result)
 
-	#
-	# AUTO GENERATED CODE FOLLOWS
-	#
+    #
+    # AUTO GENERATED CODE FOLLOWS
+    #
 
-	{{range .Signatures}}
-	def {{camel2snake .Name}}(self{{range .Params}}, {{.Name}}{{end}}):
-		status = ctypes.c_int(-100)
-		{{if ne .ParamDataName ""}}marshalled_{{.ParamDataName}} = json.dumps({{.ParamDataName}})
-		{{end}}
-		pointer = bridge.{{.Name}}(self.keyC, {{range .Params}}{{if eq .Type "data"}}marshalled_{{end}}{{.Name}}, {{end}}ctypes.byref(status))
-		return self._handle_return(status, pointer)
-	{{end}}
+    {{range .Signatures}}
+    def {{camel2snake .Name}}(self{{range .Params}}, {{.Name}}{{end}}):
+        status = ctypes.c_int(-100)
+        {{if ne .ParamDataName ""}}marshalled_{{.ParamDataName}} = json.dumps({{.ParamDataName}})
+        {{end}}
+        pointer = bridge.{{.Name}}(self.keyC, {{range .Params}}str({{if eq .Type "data"}}marshalled_{{end}}{{.Name}}), {{end}}ctypes.byref(status))
+        return self._handle_return(status, pointer)
+    {{end}}
 
 # Every bridge function returns a char*.
 # Manually informing ctypes of this prevents a segmentation fault on OSX.

--- a/bridge/templates/template.py
+++ b/bridge/templates/template.py
@@ -34,7 +34,16 @@ class Flywheel:
         status_code = status.value
         value = ctypes.cast(pointer, ctypes.c_char_p).value
 
-        # In some variants of python 3, value will not be a string, and needs to be decoded
+        # In python 2, the casted pointer value will be of type str.
+        # In python 3, it will instead be of type bytes.
+        #
+        # In python 3.6, json.loads gained the ability to process bytes objects.
+        # Earlier versions did not have this capability.
+        # So, to workaround, decode any non-str object.
+        # This could later be changed to detect the python version -.-
+        #
+        # https://bugs.python.org/issue10976
+        # https://bugs.python.org/msg275615
         if not isinstance(value, str):
             value = value.decode('utf-8')
 

--- a/bridge/templates/template.py
+++ b/bridge/templates/template.py
@@ -34,6 +34,10 @@ class Flywheel:
         status_code = status.value
         value = ctypes.cast(pointer, ctypes.c_char_p).value
 
+        # In some variants of python 3, value will not be a string, and needs to be decoded
+        if not isinstance(value, str):
+            value = value.decode('utf-8')
+
         if status_code == 0 and value is None:
             return None
         elif status_code == 0:


### PR DESCRIPTION
We should now have python2 and python3 compatibility. Closes #1.

Couldn't stop myself from re-indenting the python code. Hence, the diff is best viewed with `w=1`.

Replaces #4.