### PR TITLE
Analysis support

### DIFF
--- a/api/analysis.go
+++ b/api/analysis.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"errors"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Two extra fields beyond File
+// https://github.com/scitran/core/issues/908#issuecomment-324766048 item 1
+type AnalysisFile struct {
+	Name   string  `json:"name,omitempty"`
+	Origin *Origin `json:"origin,omitempty"`
+	Size   int     `json:"size,omitempty"`
+
+	Modality     string   `json:"modality,omitempty"`
+	Mimetype     string   `json:"mimetype,omitempty"`
+	Measurements []string `json:"measurements,omitempty"`
+	Type         string   `json:"type,omitempty"`
+	Tags         []string `json:"tags,omitempty"`
+
+	Input  bool `json:"input,omitempty"`
+	Output bool `json:"output,omitempty"`
+
+	Info map[string]interface{} `json:"info,omitempty"`
+
+	Created  *time.Time `json:"created,omitempty"`
+	Modified *time.Time `json:"modified,omitempty"`
+}
+
+type Analysis struct {
+	Id     string              `json:"_id,omitempty"`
+	Name   string              `json:"label,omitempty"`
+	Parent *ContainerReference `json:"parent,omitempty"`
+
+	Description string `json:"description,omitempty"`
+
+	// Treat this as a origin of { 'type': 'user', 'id': 'this-field' }
+	User string `json:"user,omitempty"`
+
+	Notes []*Note `json:"notes,omitempty"`
+
+	// For now, jobs are always inflated by the endpoints we fetch them through.
+	// https://github.com/scitran/core/issues/908#issuecomment-324766048 item 2
+	Job *Job `json:"job,omitempty"`
+
+	Created  *time.Time `json:"created,omitempty"`
+	Modified *time.Time `json:"modified,omitempty"`
+
+	Files []*AnalysisFile `json:"files,omitempty"`
+
+	Public      bool          `json:"public,omitempty"`
+	Permissions []*Permission `json:"permissions,omitempty"`
+}
+
+func (c *Client) AddSessionAnalysis(sessionId string, analysis *Analysis, job *Job) (string, *http.Response, error) {
+	var aerr *Error
+	var response *IdResponse
+	var result string
+
+	body := map[string]interface{}{
+		"analysis": analysis,
+		"job":      job,
+	}
+
+	// 'job=true' flag indicates new behavior
+	// https://github.com/scitran/core/issues/908#issuecomment-324766048 item 3
+	resp, err := c.New().Post("sessions/"+sessionId+"/analyses?job=true").BodyJSON(body).Receive(&response, &aerr)
+
+	if response != nil {
+		result = response.Id
+	}
+
+	return result, resp, Coalesce(err, aerr)
+}
+
+func (c *Client) AddSessionAnalysisNote(sessionId string, analysisId string, text string) (*http.Response, error) {
+	var aerr *Error
+	var response *ModifiedResponse
+
+	body := &Note{
+		Text: text,
+	}
+
+	resp, err := c.New().Post("sessions/"+sessionId+"/analyses/"+analysisId+"/notes").BodyJSON(body).Receive(&response, &aerr)
+
+	// Should not have to check this count
+	// https://github.com/scitran/core/issues/680
+	if err == nil && aerr == nil && response.ModifiedCount != 1 {
+		return resp, errors.New("Modifying session analysis on " + sessionId + " returned " + strconv.Itoa(response.ModifiedCount) + " instead of 1")
+	}
+
+	return resp, Coalesce(err, aerr)
+}

--- a/api/def.go
+++ b/api/def.go
@@ -17,6 +17,15 @@ type Permission struct {
 	Level string `json:"access"`
 }
 
+type Note struct {
+	Id     string `json:"id,omitempty"`
+	UserId string `json:"user,omitempty"`
+	Text   string `json:"text,omitempty"`
+
+	Created  *time.Time `json:"created,omitempty"`
+	Modified *time.Time `json:"modified,omitempty"`
+}
+
 type Origin struct {
 	Id     string `json:"id,omitempty"`
 	Method string `json:"method,omitempty"`
@@ -54,13 +63,4 @@ type ModifiedAndJobsResponse struct {
 // DeleteResponse is used for endpoints that respond with a count of deleted objects.
 type DeletedResponse struct {
 	DeletedCount int `json:"deleted"`
-}
-
-type Note struct {
-	Id     string `json:"id,omitempty"`
-	UserId string `json:"user,omitempty"`
-	Text   string `json:"text,omitempty"`
-
-	Created  *time.Time `json:"created,omitempty"`
-	Modified *time.Time `json:"modified,omitempty"`
 }

--- a/api/gear.go
+++ b/api/gear.go
@@ -37,14 +37,14 @@ type Gear struct {
 type GearCategory string
 
 const (
-	Utility  GearCategory = "utility"
-	Analysis GearCategory = "analysis"
+	UtilityGear  GearCategory = "utility"
+	AnalysisGear GearCategory = "analysis"
 
 	// Legacy category; equivalent to Utility
-	Converter GearCategory = "converter"
+	ConverterGear GearCategory = "converter"
 
 	// Legacy category; equivalent to Utility
-	Qa GearCategory = "qa"
+	QaGear GearCategory = "qa"
 )
 
 type GearDoc struct {

--- a/api/session.go
+++ b/api/session.go
@@ -41,6 +41,8 @@ type Session struct {
 	Public      bool          `json:"public,omitempty"`
 	Archived    *bool         `json:"archived,omitempty"`
 	Permissions []*Permission `json:"permissions,omitempty"`
+
+	Analyses []*Analysis `json:"analyses,omitempty"`
 }
 
 func (c *Client) GetAllSessions() ([]*Session, *http.Response, error) {

--- a/bridge/generator/scan.go
+++ b/bridge/generator/scan.go
@@ -217,6 +217,9 @@ func GetRelevantFunctionSignatures(path string) (*token.FileSet, []*ast.FuncDecl
 			"DownloadFromSession",
 			"DownloadFromAcquisition",
 			"DownloadFromCollection",
+
+			// Two complex data types in one signature
+			"AddSessionAnalysis",
 		}
 		if stringInSlice(name, blacklist) {
 			return false

--- a/bridge/generator/tree.go
+++ b/bridge/generator/tree.go
@@ -85,7 +85,7 @@ func isDataExpr(ex ast.Expr) (bool, string, bool) {
 	name := ident.Name
 
 	// Whitelist; could replace with lexing later
-	whitelist := []string{"Acquisition", "Batch", "BatchProposal", "Collection", "Client", "Config", "ContainerReference", "DeletedResponse", "Error", "FileFields", "FileReference", "Formula", "FormulaResult", "Gear", "GearDoc", "GearSource", "Group", "IdResponse", "Input", "Job", "JobLog", "JobLogStatement", "Key", "ModifiedAndJobsResponse", "ModifiedResponse", "Note", "Origin", "Output", "Permission", "ProgressReader", "Project", "Result", "SearchResponseList", "SearchQuery", "Session", "Subject", "Target", "UploadResponse", "UploadSource", "User", "Version"}
+	whitelist := []string{"Acquisition", "Analysis", "Batch", "BatchProposal", "Collection", "Client", "Config", "ContainerReference", "DeletedResponse", "Error", "FileFields", "FileReference", "Formula", "FormulaResult", "Gear", "GearDoc", "GearSource", "Group", "IdResponse", "Input", "Job", "JobLog", "JobLogStatement", "Key", "ModifiedAndJobsResponse", "ModifiedResponse", "Note", "Origin", "Output", "Permission", "ProgressReader", "Project", "Result", "SearchResponseList", "SearchQuery", "Session", "Subject", "Target", "UploadResponse", "UploadSource", "User", "Version"}
 
 	if stringInSlice(name, whitelist) {
 		return true, "api." + name, true

--- a/readme.md
+++ b/readme.md
@@ -68,6 +68,11 @@ Add note to a container                          | X       | X      | X      | X
 Upload tag to a container                        | X       | X      | X      | X
 Get jobs that involve container                  |         |        |        |
 &nbsp;                                           |         |        |        |
+Set file attributes                              | X       | X      | X      | X
+Set file info fields                             | X       | X      | X      | X
+Replaces all file info fields                    | X       | X      | X      | X
+Delete file info fields                          | X       | X      | X      | X
+&nbsp;                                           |         |        |        |
 Get all collections                              | X       | X      | X      | X
 Get collection                                   | X       | X      | X      | X
 Add collection                                   | X       | X      | X      | X
@@ -80,7 +85,8 @@ Get collection's session's acquisitions          | X       | X      | X      | X
 Delete collection                                | X       | X      | X      | X
 Add note to a collection                         | X       | X      | X      | X
 &nbsp;                                           |         |        |        |
-Support for analyses                             |         |        |        |
+Create analysis                                  | X       |        |        |
+Add note to analysis                             | X       | X      | X      | X
 &nbsp;                                           |         |        |        |
 Resolve path to route                            |         |        |        |
 &nbsp;                                           |         |        |        |

--- a/tests/analysis_test.go
+++ b/tests/analysis_test.go
@@ -1,0 +1,103 @@
+package tests
+
+import (
+	"time"
+
+	. "github.com/smartystreets/assertions"
+
+	"flywheel.io/sdk/api"
+)
+
+func (t *F) TestAnalyses() {
+	_, _, sessionId := t.createTestSession()
+	gearId := t.createTestGear()
+
+	src := UploadSourceFromString("yeats.txt", "A gaze blank and pitiless as the sun,")
+	progress, resultChan := t.UploadToSession(sessionId, src)
+	t.checkProgressChanEndsWith(progress, 37)
+	t.So(<-resultChan, ShouldBeNil)
+
+	analysis := &api.Analysis{
+		Name:        RandString(),
+		Description: RandString(),
+	}
+
+	filereference := &api.FileReference{
+		Id:   sessionId,
+		Type: "session",
+		Name: "yeats.txt",
+	}
+
+	tag := RandString()
+
+	job := &api.Job{
+		GearId: gearId,
+		Inputs: map[string]interface{}{
+			"any-file": filereference,
+		},
+		Tags: []string{tag},
+	}
+
+	anaId, _, err := t.AddSessionAnalysis(sessionId, analysis, job)
+	t.So(err, ShouldBeNil)
+
+	session, _, err := t.GetSession(sessionId)
+	t.So(err, ShouldBeNil)
+
+	t.So(session.Analyses, ShouldHaveLength, 1)
+	rAna := session.Analyses[0]
+
+	t.So(rAna.Id, ShouldEqual, anaId)
+	t.So(rAna.User, ShouldNotBeEmpty)
+	t.So(rAna.Job.State, ShouldEqual, api.Pending)
+	now := time.Now()
+	t.So(*rAna.Created, ShouldHappenBefore, now)
+	t.So(*rAna.Modified, ShouldHappenBefore, now)
+	t.So(rAna.Files, ShouldHaveLength, 1)
+	t.So(rAna.Files[0].Name, ShouldEqual, "yeats.txt")
+	t.So(rAna.Files[0].Input, ShouldBeTrue)
+
+	// Run the job
+	_, err = t.ChangeJobState(rAna.Job.Id, api.Running)
+	t.So(err, ShouldBeNil)
+
+	//
+	// We can't test further than this, because /engine requires drone.
+	//
+
+	// Ad-hoc implementation of engine upload
+	// src2 := UploadSourceFromString("yeats-result.txt", "And what rough beast, its hour come round at last,")
+	// url := "engine?level=analysis&id=" + anaId + "&job=" + rAna.Job.Id
+	// progress2, resultChan2 := t.UploadSimple(url, nil, src2)
+	// t.checkProgressChanEndsWith(progress2, 50)
+	// t.So(<-resultChan2, ShouldBeNil)
+
+	// Check that the result file exists
+	// session, _, err := t.GetSession(sessionId)
+	// t.So(err, ShouldBeNil)
+
+	// t.So(session.Analyses, ShouldHaveLength, 1)
+	// rAna := session.Analyses[0]
+
+	_, err = t.ChangeJobState(rAna.Job.Id, api.Complete)
+	t.So(err, ShouldBeNil)
+
+	// Analysis notes
+	text := RandString()
+	_, err = t.AddSessionAnalysisNote(sessionId, anaId, text)
+	t.So(err, ShouldBeNil)
+
+	// Check
+	session, _, err = t.GetSession(sessionId)
+	t.So(err, ShouldBeNil)
+	t.So(session.Analyses, ShouldHaveLength, 1)
+	rAna = session.Analyses[0]
+	t.So(rAna.Notes, ShouldHaveLength, 1)
+	t.So(rAna.Notes[0].UserId, ShouldNotBeEmpty)
+	t.So(rAna.Notes[0].Text, ShouldEqual, text)
+	now2 := time.Now()
+	t.So(*rAna.Notes[0].Created, ShouldHappenBefore, now2)
+	t.So(*rAna.Notes[0].Modified, ShouldHappenBefore, now2)
+	t.So(*rAna.Modified, ShouldHappenAfter, now)
+	t.So(*rAna.Modified, ShouldHappenBefore, now2)
+}

--- a/tests/gear_test.go
+++ b/tests/gear_test.go
@@ -22,7 +22,7 @@ func (t *F) TestGears() {
 	}
 
 	gearDoc := &api.GearDoc{
-		Category: api.Utility,
+		Category: api.UtilityGear,
 		Gear:     gear,
 	}
 
@@ -57,6 +57,11 @@ func (t *F) TestGears() {
 }
 
 func (t *F) createTestGear() string {
+
+	//
+	// Do not modify the below gear document without checking the other callees!
+	//
+
 	gear := &api.Gear{
 		Name:        RandStringLower(),
 		Label:       RandString(),

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -56,6 +56,7 @@ func (t *F) TestSessions() {
 	rSession.Notes = nil
 	rSession.Tags = nil
 	rSession.Info = nil
+	rSession.Analyses = nil
 	rSession.Subject = &api.Subject{
 		Id:   rSession.Subject.Id,
 		Code: rSession.Subject.Code,


### PR DESCRIPTION
Supports creation, adding a note, and retrieving through a parent container. Closes #21.

Scoped to sessions, the better to keep things simple until analyses are first-class citizens.
Ref https://github.com/scitran/core/issues/908#issuecomment-324766048 item 4.

Pair-programmed with @nagem.
Todo: Bridge compat