### PR TITLE
Fixes #44: Update savejson method to save booleans as true/false

### DIFF
--- a/bridge/dist/matlab/readme.md
+++ b/bridge/dist/matlab/readme.md
@@ -10,6 +10,8 @@ Use the Flywheel Matlab SDK to do the following:
 ### Requirements
 Requires [JSONLab](https://www.mathworks.com/matlabcentral/fileexchange/33381-jsonlab--a-toolbox-to-encode-decode-json-files) Matlab package.
 
+NOTE: The `ParseLogical` option for the `savejson` function is set to 1. This causes any logical `1` or `0` to be set to `true` or `false`, respectively, when written to a JSON string. This is needed for the search queries within the SDK. If a 1 or 0 is needed to be written out to JSON, ensure that it is a `1` or `0` of class `double` as opposed to the `logical` class. 
+
 ### Example Usage
 Before starting, add JSONLab and Flywheel Matlab SDK to project path.
 

--- a/bridge/templates/template.binary.m
+++ b/bridge/templates/template.binary.m
@@ -61,7 +61,7 @@ classdef Flywheel
             {{if ne .ParamDataName ""}}oldField = 'id';
             newField = 'x0x5F_id';
             {{.ParamDataName}} = Flywheel.replaceField({{.ParamDataName}},oldField,newField);
-            {{.ParamDataName}} = savejson('',{{.ParamDataName}});
+            {{.ParamDataName}} = savejson('',{{.ParamDataName}},'ParseLogical',1);
             {{end -}}
             [status,cmdout] = system([obj.folder '/sdk {{.Name}} ' obj.key ' ' {{range .Params}} '''' {{.Name}} ''' '{{end -}}]);
 

--- a/bridge/templates/template.m
+++ b/bridge/templates/template.m
@@ -60,7 +60,7 @@ classdef Flywheel
             {{if ne .ParamDataName ""}}oldField = 'id';
             newField = 'x0x5F_id';
             {{.ParamDataName}} = Flywheel.replaceField({{.ParamDataName}},oldField,newField);
-            {{.ParamDataName}} = savejson('',{{.ParamDataName}});
+            {{.ParamDataName}} = savejson('',{{.ParamDataName}},'ParseLogical',1);
             {{end -}}
             pointer = calllib('flywheelBridge','{{.Name}}',obj.key,{{range .Params}}{{.Name}},{{end -}} statusPtr);
             result = Flywheel.handleJson(statusPtr,pointer);


### PR DESCRIPTION
This will allow for search to work properly when using booleans.

For example, this search struct that Brian is seeking to use. 

```
searchStruct = struct('return_type', 'session', ...
        'all_data', true, ...
        'filters', ...
        {{struct('match', struct('project_0x2E_label', 'UMN')), ...
        struct('match', struct('analysis_0x2E_label', 'AFQ')), ...
        struct('term', struct('subject_0x2E_code', '4279')), ...
        }});
sessions = fw.search(searchStruct).results;
```