### PR TITLE
Update JSONlab to JSONio

### DIFF
--- a/bridge/dist/matlab-binary/testDrive.m
+++ b/bridge/dist/matlab-binary/testDrive.m
@@ -1,0 +1,178 @@
+%% Test methods in Flywheel.m
+%% Setup
+disp('Setup')
+% Before running this script, ensure the following paths were added
+%   path to Flywheel.m to be tested
+%   path to JSONlab
+%   set SdkTestKey environment variable as user API key
+%       ex: setenv('SdkTestKey', APIKEY)
+
+% Create string to be used in testdrive
+testString = 'aeu84sdfarew2h23333';
+% A test file
+filename = 'test.txt';
+fid = fopen(filename, 'w');
+fprintf(fid, 'This is a test file');
+fclose(fid);
+% Define error message
+errMsg = 'Strings not equal';
+
+% Create client
+apiKey = getenv('SdkTestKey');
+fw = Flywheel(apiKey);
+
+% Check that data can flow back & forth across the bridge
+bridgeResponse = fw.testBridge('world');
+assert(strcmp(bridgeResponse,'Hello world'), errMsg)
+
+%% Users
+disp('Testing Users')
+user = fw.getCurrentUser();
+assert(~isempty(user.id))
+
+users = fw.getAllUsers();
+assert(length(users) >= 1, 'No users returned')
+
+% add a new user
+email = strcat(testString, '@', testString, '.com');
+userId = fw.addUser(struct('id',email,'email',email,'firstname',testString,'lastname',testString));
+
+% modify the new user
+fw.modifyUser(userId, struct('firstname', 'John'));
+user2 = fw.getUser(userId);
+assert(strcmp(user2.email, email), errMsg)
+assert(strcmp(user2.firstname,'John'), errMsg)
+
+fw.deleteUser(userId);
+
+%% Groups
+disp('Testing Groups')
+
+groupId = fw.addGroup(struct('id',testString));
+
+fw.addGroupTag(groupId, 'blue');
+fw.modifyGroup(groupId, struct('label','testdrive'));
+
+groups = fw.getAllGroups();
+assert(~isempty(groups))
+
+group = fw.getGroup(groupId);
+assert(strcmp(group.tags{1},'blue'), errMsg)
+assert(strcmp(group.label,'testdrive'), errMsg)
+
+%% Projects
+disp('Testing Projects')
+
+projectId = fw.addProject(struct('label',testString,'group',groupId));
+
+fw.addProjectTag(projectId, 'blue');
+fw.modifyProject(projectId, struct('label','testdrive'));
+fw.addProjectNote(projectId, 'This is a note');
+
+projects = fw.getAllProjects();
+assert(~isempty(projects), errMsg)
+
+
+fw.uploadFileToProject(projectId, filename);
+fw.downloadFileFromProject(projectId, filename, '/tmp/download.txt');
+
+project = fw.getProject(projectId);
+assert(strcmp(project.tags{1},'blue'), errMsg)
+assert(strcmp(project.label,'testdrive'), errMsg)
+assert(strcmp(project.notes.text, 'This is a note'), errMsg)
+assert(strcmp(project.files.name, filename), errMsg)
+s = dir('/tmp/download.txt');
+assert(project.files.size == s.bytes, errMsg)
+
+%% Sessions
+disp('Testing Sessions')
+
+sessionId = fw.addSession(struct('label', testString, 'project', projectId));
+
+fw.addSessionTag(sessionId, 'blue');
+fw.modifySession(sessionId, struct('label', 'testdrive'));
+fw.addSessionNote(sessionId, 'This is a note');
+
+sessions = fw.getProjectSessions(projectId);
+assert(~isempty(sessions), errMsg)
+
+sessions = fw.getAllSessions();
+assert(~isempty(sessions), errMsg)
+
+fw.uploadFileToSession(sessionId, filename);
+fw.downloadFileFromSession(sessionId, filename, '/tmp/download2.txt');
+
+session = fw.getSession(sessionId);
+assert(strcmp(session.tags{1}, 'blue'), errMsg)
+assert(strcmp(session.label, 'testdrive'), errMsg)
+assert(strcmp(session.notes.text, 'This is a note'), errMsg)
+assert(strcmp(session.files.name, filename), errMsg)
+s = dir('/tmp/download2.txt');
+assert(session.files.size == s.bytes, errMsg)
+
+%% Acquisitions
+disp('Testing Acquisitions')
+
+acqId = fw.addAcquisition(struct('label', testString,'session', sessionId));
+
+fw.addAcquisitionTag(acqId, 'blue');
+fw.modifyAcquisition(acqId, struct('label', 'testdrive'));
+fw.addAcquisitionNote(acqId, 'This is a note');
+
+acqs = fw.getSessionAcquisitions(sessionId);
+assert(~isempty(acqs), errMsg)
+
+acqs = fw.getAllAcquisitions();
+assert(~isempty(acqs), errMsg)
+
+fw.uploadFileToAcquisition(acqId, filename);
+fw.downloadFileFromAcquisition(acqId, filename, '/tmp/download3.txt');
+
+acq = fw.getAcquisition(acqId);
+assert(strcmp(acq.tags{1},'blue'), errMsg)
+assert(strcmp(acq.label,'testdrive'), errMsg)
+assert(strcmp(acq.notes.text, 'This is a note'), errMsg)
+assert(strcmp(acq.files.name, filename), errMsg)
+s = dir('/tmp/download3.txt');
+assert(session.files.size == s.bytes, errMsg)
+
+%% Gears
+disp('Testing Gears')
+
+gearId = fw.addGear(struct('category','converter','exchange', struct('git0x2Dcommit','example','rootfs0x2Dhash','sha384:example','rootfs0x2Durl','https://example.example'),'gear', struct('name','test-drive-gear','label','Test Drive Gear','version','3','author','None','description','An empty example gear','license','Other','source','http://example.example','url','http://example.example','inputs', struct('x', struct('base','file')))));
+
+gear = fw.getGear(gearId);
+assert(strcmp(gear.gear.name, 'test-drive-gear'), errMsg)
+
+gears = fw.getAllGears();
+assert(~isempty(gears), errMsg)
+
+job2Add = struct('gear_id',gearId,'state','pending','inputs',struct('x',struct('type','acquisition','id',acqId,'name',filename)));
+jobId = fw.addJob(job2Add);
+
+job = fw.getJob(jobId);
+assert(strcmp(job.gear_id,gearId), errMsg)
+
+logs = fw.getJobLogs(jobId);
+% Likely will not have anything in them yet
+
+%% Misc
+disp('Testing Misc')
+
+config = fw.getConfig();
+assert(~isempty(config), errMsg)
+
+fwVersion = fw.getVersion();
+assert(fwVersion.database >= 25, errMsg)
+
+%% Cleanup
+disp('Cleanup')
+
+fw.deleteAcquisition(acqId);
+fw.deleteSession(sessionId);
+fw.deleteProject(projectId);
+fw.deleteGroup(groupId);
+fw.deleteGear(gearId);
+
+disp('')
+disp('Test drive complete.')

--- a/bridge/dist/matlab/testDrive.m
+++ b/bridge/dist/matlab/testDrive.m
@@ -8,7 +8,7 @@ disp('Setup')
 %       ex: setenv('SdkTestKey', APIKEY)
 
 % Create string to be used in testdrive
-testString = 'aeu8457bjclsj97v2h';
+testString = '123235jakhf7sadf7v';
 % A test file
 filename = 'test.txt';
 fid = fopen(filename, 'w');
@@ -79,10 +79,10 @@ fw.downloadFileFromProject(projectId, filename, '/tmp/download.txt');
 project = fw.getProject(projectId);
 assert(strcmp(project.tags{1},'blue'), errMsg)
 assert(strcmp(project.label,'testdrive'), errMsg)
-assert(strcmp(project.notes{1,1}.text, 'This is a note'), errMsg)
-assert(strcmp(project.files{1,1}.name, filename), errMsg)
+assert(strcmp(project.notes.text, 'This is a note'), errMsg)
+assert(strcmp(project.files.name, filename), errMsg)
 s = dir('/tmp/download.txt');
-assert(project.files{1,1}.size == s.bytes, errMsg)
+assert(project.files.size == s.bytes, errMsg)
 
 %% Sessions
 disp('Testing Sessions')
@@ -105,10 +105,10 @@ fw.downloadFileFromSession(sessionId, filename, '/tmp/download2.txt');
 session = fw.getSession(sessionId);
 assert(strcmp(session.tags{1}, 'blue'), errMsg)
 assert(strcmp(session.label, 'testdrive'), errMsg)
-assert(strcmp(session.notes{1,1}.text, 'This is a note'), errMsg)
-assert(strcmp(session.files{1,1}.name, filename), errMsg)
+assert(strcmp(session.notes.text, 'This is a note'), errMsg)
+assert(strcmp(session.files.name, filename), errMsg)
 s = dir('/tmp/download2.txt');
-assert(session.files{1,1}.size == s.bytes, errMsg)
+assert(session.files.size == s.bytes, errMsg)
 
 %% Acquisitions
 disp('Testing Acquisitions')
@@ -131,15 +131,15 @@ fw.downloadFileFromAcquisition(acqId, filename, '/tmp/download3.txt');
 acq = fw.getAcquisition(acqId);
 assert(strcmp(acq.tags{1},'blue'), errMsg)
 assert(strcmp(acq.label,'testdrive'), errMsg)
-assert(strcmp(acq.notes{1,1}.text, 'This is a note'), errMsg)
-assert(strcmp(acq.files{1,1}.name, filename), errMsg)
+assert(strcmp(acq.notes.text, 'This is a note'), errMsg)
+assert(strcmp(acq.files.name, filename), errMsg)
 s = dir('/tmp/download3.txt');
-assert(session.files{1,1}.size == s.bytes, errMsg)
+assert(session.files.size == s.bytes, errMsg)
 
 %% Gears
 disp('Testing Gears')
 
-gearId = fw.addGear(struct('category','converter','exchange', struct('git_0x2D_commit','example','rootfs_0x2D_hash','sha384:example','rootfs_0x2D_url','https://example.example'),'gear', struct('name','test-drive-gear','label','Test Drive Gear','version','3','author','None','description','An empty example gear','license','Other','source','http://example.example','url','http://example.example','inputs', struct('x', struct('base','file')))));
+gearId = fw.addGear(struct('category','converter','exchange', struct('git0x2Dcommit','example','rootfs0x2Dhash','sha384:example','rootfs0x2Durl','https://example.example'),'gear', struct('name','test-drive-gear','label','Test Drive Gear','version','3','author','None','description','An empty example gear','license','Other','source','http://example.example','url','http://example.example','inputs', struct('x', struct('base','file')))));
 
 gear = fw.getGear(gearId);
 assert(strcmp(gear.gear.name, 'test-drive-gear'), errMsg)
@@ -147,7 +147,7 @@ assert(strcmp(gear.gear.name, 'test-drive-gear'), errMsg)
 gears = fw.getAllGears();
 assert(~isempty(gears), errMsg)
 
-job2Add = struct('gear_id',gearId,'state','pending','inputs',struct('x',struct('type','acquisition','id',acqId,'name','testDrive.m')));
+job2Add = struct('gear_id',gearId,'state','pending','inputs',struct('x',struct('type','acquisition','id',acqId,'name',filename)));
 jobId = fw.addJob(job2Add);
 
 job = fw.getJob(jobId);

--- a/bridge/templates/template.binary.m
+++ b/bridge/templates/template.binary.m
@@ -17,13 +17,13 @@ classdef Flywheel
                 throw(ME)
             end
             obj.key = apiKey;
-            % Check if JSONlab is in path
-            if ~exist('savejson')
-                ME = MException('FlywheelException:JSONlab', 'JSONlab function savejson is not loaded. Please install JSONlab and add to path.')
+            % Check if JSONio is in path
+            if ~exist('jsonread')
+                ME = MException('FlywheelException:JSONio', 'JSONio function jsonsave is not loaded. Please install JSONio and add to path.')
                 throw(ME)
             end
-            if ~exist('loadjson')
-                ME = MException('FlywheelException:JSONlab', 'JSONlab function loadjson is not loaded. Please install JSONlab and add to path.')
+            if ~exist('jsonwrite')
+                ME = MException('FlywheelException:JSONio', 'JSONio function jsonwrite is not loaded. Please install JSONio and add to path.')
                 throw(ME)
             end
 
@@ -59,9 +59,10 @@ classdef Flywheel
             % {{camel2lowercamel .Name}}({{range $ind, $val := .Params}}{{.Name}}{{if lt $ind $length}}, {{end}}{{end -}})
 
             {{if ne .ParamDataName ""}}oldField = 'id';
-            newField = 'x0x5F_id';
+            newField = 'x0x5Fid';
             {{.ParamDataName}} = Flywheel.replaceField({{.ParamDataName}},oldField,newField);
-            {{.ParamDataName}} = savejson('',{{.ParamDataName}},'ParseLogical',1);
+            opts = struct('replacementStyle','hex');
+            {{.ParamDataName}} = jsonwrite({{.ParamDataName}},opts);
             {{end -}}
             [status,cmdout] = system([obj.folder '/sdk {{.Name}} ' obj.key ' ' {{range .Params}} '''' {{.Name}} ''' '{{end -}}]);
 
@@ -75,23 +76,23 @@ classdef Flywheel
             version = '{{.Version}}';
         end
         function structFromJson = handleJson(statusPtr,ptrValue)
-            % Handle JSON using JSONlab
+            % Handle JSON using JSONio
             statusValue = statusPtr;
 
             % If status indicates success, load JSON
             if statusValue == 0
                 % Interpret JSON string blob as a struct object
-                loadedJson = loadjson(ptrValue);
+                loadedJson = jsonread(ptrValue);
                 % loadedJson contains status, message and data, only return
                 %   the data information.
                 dataFromJson = loadedJson.data;
                 %  Call replaceField on loadedJson to replace x0x5F_id with id
-                structFromJson = Flywheel.replaceField(dataFromJson,'x0x5F_id','id');
+                structFromJson = Flywheel.replaceField(dataFromJson,'x_id','id');
             % Otherwise, nonzero statusCode indicates an error
             else
                 % Try to load message from the JSON
                 try
-                    loadedJson = loadjson(ptrValue);
+                    loadedJson = jsonread(ptrValue);
                     msg = loadedJson.message;
                     ME = MException('FlywheelException:handleJson', msg);
                 % If unable to load message, throw an 'unknown' error

--- a/bridge/templates/template.binary.m
+++ b/bridge/templates/template.binary.m
@@ -61,6 +61,7 @@ classdef Flywheel
             {{if ne .ParamDataName ""}}oldField = 'id';
             newField = 'x0x5Fid';
             {{.ParamDataName}} = Flywheel.replaceField({{.ParamDataName}},oldField,newField);
+            % Indicate to JSONio to replace hex values with corresponding character, i.e. 'x0x5F' -> '_' and '0x2D' -> '-'
             opts = struct('replacementStyle','hex');
             {{.ParamDataName}} = jsonwrite({{.ParamDataName}},opts);
             {{end -}}

--- a/bridge/templates/template.m
+++ b/bridge/templates/template.m
@@ -60,6 +60,7 @@ classdef Flywheel
             {{if ne .ParamDataName ""}}oldField = 'id';
             newField = 'x0x5Fid';
             {{.ParamDataName}} = Flywheel.replaceField({{.ParamDataName}},oldField,newField);
+            % Indicate to JSONio to replace hex values with corresponding character, i.e. 'x0x5F' -> '_' and '0x2D' -> '-'
             opts = struct('replacementStyle','hex');
             {{.ParamDataName}} = jsonwrite({{.ParamDataName}},opts);
             {{end -}}

--- a/bridge/templates/template.m
+++ b/bridge/templates/template.m
@@ -16,13 +16,13 @@ classdef Flywheel
                 throw(ME)
             end
             obj.key = apiKey;
-            % Check if JSONlab is in path
-            if ~exist('savejson')
-                ME = MException('FlywheelException:JSONlab', 'JSONlab function savejson is not loaded. Please install JSONlab and add to path.')
+            % Check if JSONio is in path
+            if ~exist('jsonread')
+                ME = MException('FlywheelException:JSONio', 'JSONio function jsonread is not loaded. Please install JSONio and add to path.')
                 throw(ME)
             end
-            if ~exist('loadjson')
-                ME = MException('FlywheelException:JSONlab', 'JSONlab function loadjson is not loaded. Please install JSONlab and add to path.')
+            if ~exist('jsonwrite')
+                ME = MException('FlywheelException:JSONio', 'JSONio function jsonwrite is not loaded. Please install JSONio and add to path.')
                 throw(ME)
             end
             % Load flywheel shared library
@@ -58,9 +58,10 @@ classdef Flywheel
 
             statusPtr = libpointer('int32Ptr',-100);
             {{if ne .ParamDataName ""}}oldField = 'id';
-            newField = 'x0x5F_id';
+            newField = 'x0x5Fid';
             {{.ParamDataName}} = Flywheel.replaceField({{.ParamDataName}},oldField,newField);
-            {{.ParamDataName}} = savejson('',{{.ParamDataName}},'ParseLogical',1);
+            opts = struct('replacementStyle','hex');
+            {{.ParamDataName}} = jsonwrite({{.ParamDataName}},opts);
             {{end -}}
             pointer = calllib('flywheelBridge','{{.Name}}',obj.key,{{range .Params}}{{.Name}},{{end -}} statusPtr);
             result = Flywheel.handleJson(statusPtr,pointer);
@@ -73,22 +74,22 @@ classdef Flywheel
             version = '{{.Version}}';
         end
         function structFromJson = handleJson(statusPtr,ptrValue)
-            % Handle JSON using JSONlab
+            % Handle JSON using JSONio
             statusValue = statusPtr.Value;
             % If status indicates success, load JSON
             if statusValue == 0
                 % Interpret JSON string blob as a struct object
-                loadedJson = loadjson(ptrValue);
+                loadedJson = jsonread(ptrValue);
                 % loadedJson contains status, message and data, only return
                 %   the data information.
                 dataFromJson = loadedJson.data;
-                %  Call replaceField on loadedJson to replace x0x5F_id with id
-                structFromJson = Flywheel.replaceField(dataFromJson,'x0x5F_id','id');
+                %  Call replaceField on loadedJson to replace x_id with id
+                structFromJson = Flywheel.replaceField(dataFromJson,'x_id','id');
             % Otherwise, nonzero statusCode indicates an error
             else
                 % Try to load message from the JSON
                 try
-                    loadedJson = loadjson(ptrValue);
+                    loadedJson = jsonread(ptrValue);
                     msg = loadedJson.message;
                     ME = MException('FlywheelException:handleJson', msg);
                 % If unable to load message, throw an 'unknown' error

--- a/sdk.go
+++ b/sdk.go
@@ -4,7 +4,7 @@ import (
 	_ "flywheel.io/sdk/api"
 )
 
-var Version = "0.2.0"
+var Version = "0.2.1"
 
 func main() {
 


### PR DESCRIPTION
Fixes #48

JSONio has all the functionality that JSONlab has. This was an easy update.
This has been updated for both matlab and matlab-binary.

TestDrive.m successfully ran for both matlab and matlab-binary. 