### PR TITLE
Simplify default Search; move old search to SearchRaw

### DIFF
--- a/bridge/generator/tree.go
+++ b/bridge/generator/tree.go
@@ -85,7 +85,7 @@ func isDataExpr(ex ast.Expr) (bool, string, bool) {
 	name := ident.Name
 
 	// Whitelist; could replace with lexing later
-	whitelist := []string{"Acquisition", "Analysis", "Batch", "BatchProposal", "Collection", "Client", "Config", "ContainerReference", "DeletedResponse", "Error", "FileFields", "FileReference", "Formula", "FormulaResult", "Gear", "GearDoc", "GearSource", "Group", "IdResponse", "Input", "Job", "JobLog", "JobLogStatement", "Key", "ModifiedAndJobsResponse", "ModifiedResponse", "Note", "Origin", "Output", "Permission", "ProgressReader", "Project", "Result", "SearchResponseList", "SearchQuery", "Session", "Subject", "Target", "UploadResponse", "UploadSource", "User", "Version"}
+	whitelist := []string{"Acquisition", "Analysis", "Batch", "BatchProposal", "Collection", "Client", "Config", "ContainerReference", "DeletedResponse", "Error", "FileFields", "FileReference", "Formula", "FormulaResult", "Gear", "GearDoc", "GearSource", "Group", "IdResponse", "Input", "Job", "JobLog", "JobLogStatement", "Key", "ModifiedAndJobsResponse", "ModifiedResponse", "Note", "Origin", "Output", "Permission", "ProgressReader", "Project", "Result", "SearchResponse", "RawSearchResponseList", "SearchQuery", "Session", "Subject", "Target", "UploadResponse", "UploadSource", "User", "Version"}
 
 	if stringInSlice(name, whitelist) {
 		return true, "api." + name, true

--- a/tests/search_test.go
+++ b/tests/search_test.go
@@ -10,7 +10,7 @@ import (
 
 // Ref https://github.com/flywheel-io/sdk/issues/31
 func (t *F) SkipTestSearch() {
-	_, _, sessionId, acquisitionId := t.createTestAcquisition()
+	_, _, _, acquisitionId := t.createTestAcquisition()
 
 	// Get Acquisition
 	a, _, err := t.GetAcquisition(acquisitionId)
@@ -26,8 +26,7 @@ func (t *F) SkipTestSearch() {
 	sR, _, err := t.Search(s)
 	// t.So(a.Name, ShouldBeNil)
 	t.So(err, ShouldBeNil)
-	t.So(len(sR.Results), ShouldEqual, 1)
-	t.So(sR.Results[0].Source.Session.Id, ShouldEqual, sessionId)
+	t.So(len(sR), ShouldEqual, 1)
 
 	s = &api.SearchQuery{
 		ReturnType:   api.AcquisitionString,
@@ -37,6 +36,5 @@ func (t *F) SkipTestSearch() {
 	sR, _, err = t.Search(s)
 	// t.So(a.Name, ShouldBeNil)
 	t.So(err, ShouldBeNil)
-	t.So(len(sR.Results), ShouldEqual, 1)
-	t.So(sR.Results[0].Source.Acquisition.Id, ShouldEqual, acquisitionId)
+	t.So(len(sR), ShouldEqual, 1)
 }


### PR DESCRIPTION
Search now returns a simpler format, always has a result array, and offers a `limit` key that can be set to any value, or set to a negative value such as `-1` to retrieve all results.

A heavily-truncated example of the new result format:

```python
fw.search({
	'return_type': 'file', 
	'filters': [ 
		{'match': {'acquisition.label': 'T1w 1mm'}} 
	],
	'limit': -1
})

[{'file': {'created': '2017-09-27T17:20:34.344000+00:00',
            'name': 'T1w .9mm sag.dcm.zip',
            'size': 12471624,
            'type': 'dicom'},
  # ...
  'subject': {'code': 'cni/brainprint'}},
 {'file': {'created': '2017-08-28T17:52:11.857000+00:00',
            'name': 'Short axis T1W.dcm.zip',
            'size': 15680844,
            'type': 'dicom'},
  
  # ...
  'subject': {'code': '102311_strc'}}]
```

Contrast the old format, now available via SearchRaw:

```python
fw.search_raw({
	'return_type': 'file', 
	'filters': [ 
		{'match': {'acquisition.label': 'T1w 1mm'}} 
	] 
})


{'results': [{'_id': '59cbdde2941a7f00197a509d_T1w .9mm sag.dcm.zip',
               '_source': {'file': {'created': '2017-09-27T17:20:34.344000+00:00',
                                      'name': 'T1w .9mm sag.dcm.zip',
                                      'size': 12471624,
                                      'type': 'dicom'},
                            # ...
                            'subject': {'code': 'cni/brainprint'}}},
              {'_id': '59a4584c99e0c80017d179b6_Short axis T1W.dcm.zip',
               '_source': {'file': {'created': '2017-08-28T17:52:11.857000+00:00',
                                      'name': 'Short axis T1W.dcm.zip',
                                      'size': 15680844,
                                      'type': 'dicom'},
                            # ...
                            'subject': {'code': '102311_strc'}}}]}
```