### PR TITLE
Fixes #60: Fix failing upload/download unit tests

### DIFF
--- a/tests/download_test.go
+++ b/tests/download_test.go
@@ -29,7 +29,7 @@ func (t *F) TestBadDownloads() {
 
 	// Could improve this in the future
 	err := <-result
-	t.So(err.Error(), ShouldEqual, "{\"status_code\": 404, \"message\": \"The resource could not be found.\"}")
+	t.So(err.Error(), ShouldMatchRegex, "\\{\"status_code\": 404, \"message\": \"The resource could not be found.\"\\, \"request_id\": \"[^\"]+\"}")
 	t.So(buffer.String(), ShouldEqual, "")
 }
 

--- a/tests/upload_test.go
+++ b/tests/upload_test.go
@@ -28,8 +28,10 @@ func (t *F) TestBadUploads() {
 	poem := "Are full of passionate intensity."
 	source = UploadSourceFromString("yeats.txt", poem)
 	_, result = t.UploadSimple("not-an-endpoint", nil, source)
+
 	// Could improve this in the future
-	t.So((<-result).Error(), ShouldEqual, "{\"status_code\": 404, \"message\": \"The resource could not be found.\"}")
+	err := <-result
+	t.So(err.Error(), ShouldMatchRegex, "\\{\"status_code\": 404, \"message\": \"The resource could not be found.\"\\, \"request_id\": \"[^\"]+\"}")
 }
 
 // Given an upload function, container ID, filename, and content - upload & check length

--- a/tests/z-util.go
+++ b/tests/z-util.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
@@ -80,6 +81,35 @@ func ShouldBeSameTimeAs(actual interface{}, expected ...interface{}) string {
 		return fmt.Sprintf(shouldBeTimeEqual, actualTime, expectedTime, actualTime.Sub(expectedTime))
 	}
 
+	return success
+}
+
+// Helper function to compare a string against a regular expression
+const (
+	invalidRegex     = "Invalid match expression '%s': %s"
+	regexBadMatch    = "Expected '%s' to match pattern: '%s'"
+	shouldUseStrings = "You must provide string instances as arguments to this assertion."
+)
+
+func ShouldMatchRegex(actual interface{}, pattern ...interface{}) string {
+	if fail := need(1, pattern); fail != success {
+		return fail
+	}
+
+	actualString, firstOk := actual.(string)
+	patternString, secondOk := pattern[0].(string)
+
+	if !firstOk || !secondOk {
+		return shouldUseStrings
+	}
+
+	matched, err := regexp.MatchString(patternString, actualString)
+	if err != nil {
+		return fmt.Sprintf(invalidRegex, patternString, err.Error())
+	}
+	if !matched {
+		return fmt.Sprintf(regexBadMatch, actualString, patternString)
+	}
 	return success
 }
 


### PR DESCRIPTION
Fix failing tests by matching the error string against a regular expression that includes request_id.
Closes #60.

@kofalt 