### PR TITLE
Fixes 47: Ensure that the progress channel is closed …

### DIFF
--- a/tests/download_test.go
+++ b/tests/download_test.go
@@ -15,17 +15,20 @@ func (t *F) TestCreateDownloadSourceFromFilenames() {
 func (t *F) TestBadDownloads() {
 	// Invalid download source
 	source := &api.DownloadSource{}
-	_, result := t.DownloadSimple("", source)
+	progress, result := t.DownloadSimple("", source)
+	t.So(<-progress, ShouldEqual, 0)
 	t.So((<-result).Error(), ShouldEqual, "Neither destination path nor writer was set in download source")
 
 	// Nonexistant download path
 	source = &api.DownloadSource{Path: "/dev/null/does-not-exist"}
-	_, result = t.DownloadSimple("", source)
+	progress, result = t.DownloadSimple("", source)
+	t.So(<-progress, ShouldEqual, 0)
 	t.So((<-result).Error(), ShouldStartWith, "open /dev/null/does-not-exist: ")
 
 	// Bad download url
 	buffer, source := DownloadSourceToBuffer()
-	_, result = t.DownloadSimple("not-an-endpoint", source)
+	progress, result = t.DownloadSimple("not-an-endpoint", source)
+	t.So(<-progress, ShouldEqual, 0)
 
 	// Could improve this in the future
 	err := <-result


### PR DESCRIPTION
…in error paths that occur before the ProgressReader is created.

Closes #47 

@kofalt I'm open to suggestions for a cleaner way of getting the channel closed that doesn't involve repeating `close(progress)` and doesn't result in a double close panic. This is a very "C" way to do it.