### PR TITLE
Added RootMode option for Client

### DIFF
--- a/api/transport-options.go
+++ b/api/transport-options.go
@@ -24,6 +24,9 @@ type ApiKeyClientOptions struct {
 	// Use plaintext (HTTP) transport
 	InsecureUsePlaintext bool
 
+	// Enable root (Manage Site) mode
+	EnableRoot bool
+
 	// A writer to send debug request bodies to, if any
 	DebugWriter io.Writer
 }
@@ -31,6 +34,7 @@ type ApiKeyClientOptions struct {
 var DefaultApiKeyClientOptions = ApiKeyClientOptions{
 	InsecureSkipVerify:   false,
 	InsecureUsePlaintext: false,
+	EnableRoot:           false,
 }
 
 // Specify that the ApiKeyClient should not verify SSL connections.
@@ -40,6 +44,9 @@ var InsecureNoSSLVerification ApiKeyClientOption
 // Specify that the ApiKeyClient should use a plaintext HTTP transport.
 // Should only be used for development.
 var InsecureUsePlaintext ApiKeyClientOption
+
+// Specify that the ApiKeyClient should operate in Root (Manage Site) mode.
+var EnableRoot ApiKeyClientOption
 
 // Specify that the ApiKeyClient should log all request bodies to the specified Writer.
 // See DebugTransport for details.
@@ -56,5 +63,9 @@ func init() {
 
 	InsecureUsePlaintext = func(o *ApiKeyClientOptions) {
 		o.InsecureUsePlaintext = true
+	}
+
+	EnableRoot = func(o *ApiKeyClientOptions) {
+		o.EnableRoot = true
 	}
 }

--- a/api/transport.go
+++ b/api/transport.go
@@ -11,6 +11,10 @@ import (
 	"github.com/dghubble/sling"
 )
 
+type RootModeQueryStruct struct {
+	Root bool `url:"root,omitempty"`
+}
+
 // NewApiKeyClient creates a Client with the given API key and options.
 // Passing a key with an invalid format will panic.
 func NewApiKeyClient(apiKey string, options ...ApiKeyClientOption) *Client {
@@ -67,6 +71,12 @@ func NewApiKeyClient(apiKey string, options ...ApiKeyClientOption) *Client {
 		Set("User-Agent", "Flywheel SDK").
 		Path("api/").
 		Client(hc)
+
+	// Set root query param for all requests, if requested
+	if config.EnableRoot {
+		var params = &RootModeQueryStruct{Root: true}
+		sc.QueryStruct(params)
+	}
 
 	return &Client{
 		Doer:  hc,

--- a/bridge/templates/template.binary
+++ b/bridge/templates/template.binary
@@ -26,7 +26,8 @@ type CallResult struct {
 	Data interface{} `json:"data"`
 }
 
-func makeClient(apiKey string) *api.Client {
+// root (since it is passed in via commandline) should be the literal string "true" to enable root mode
+func makeClient(apiKey string, root string) *api.Client {
 
 	// Parse the key into its components, so that we can activate some bridge-only features.
 	host, port, key, err := api.ParseApiKey(apiKey)
@@ -50,6 +51,11 @@ func makeClient(apiKey string) *api.Client {
 	// No production instance should EVER be on a non-443 port.
 	if port != 443 {
 		options = append(options, api.InsecureNoSSLVerification)
+	}
+
+	// Enable root mode
+	if root == "true" {
+		options = append(options, api.EnableRoot)
 	}
 
 	// Intentionally undocumented option: if ',InsecureUsePlaintext' is appended to the key, use HTTP.
@@ -149,13 +155,15 @@ func BuildCommand(version string) *cobra.Command {
 	{{range .Signatures}}
 	cmd = &cobra.Command{
 		Use: "{{.Name}} [api_key]{{range .Params}} [{{.Name}}]{{end}}",
-		Args: cobra.ExactArgs({{.LastParamIndex}} + 2),
+		Args: cobra.ExactArgs({{.LastParamIndex}} + 3),
 
 		Run: func(cmd *cobra.Command, args []string) {
 
 			// Grab data vars out of args
 			apiKey := args[0]
-			{{range $ind, $val := .Params}}{{$val.Name}} := args[{{$ind}} + 1]
+			root := args[1]
+
+			{{range $ind, $val := .Params}}{{$val.Name}} := args[{{$ind}} + 2]
 			{{end}}
 
 			{{if ne .ParamDataName ""}}
@@ -167,7 +175,7 @@ func BuildCommand(version string) *cobra.Command {
 			{{end}}
 
 			{{ $length := .LastResultIndex }}
-			{{range $ind, $val := .Results}}{{.Name}}{{if lt $ind $length}}, {{end}}{{end}} := makeClient(apiKey).{{.Name}}({{ $length := .LastParamIndex }}{{ $ShouldDeref := .ShouldDeref }}{{range $ind, $val := .Params}}{{if eq $val.Type "data"}}{{if $ShouldDeref }}&{{end}}parsed{{end}}{{$val.Name}}{{if lt $ind $length}}, {{end}}{{end}})
+			{{range $ind, $val := .Results}}{{.Name}}{{if lt $ind $length}}, {{end}}{{end}} := makeClient(apiKey, root).{{.Name}}({{ $length := .LastParamIndex }}{{ $ShouldDeref := .ShouldDeref }}{{range $ind, $val := .Params}}{{if eq $val.Type "data"}}{{if $ShouldDeref }}&{{end}}parsed{{end}}{{$val.Name}}{{if lt $ind $length}}, {{end}}{{end}})
 
 			format({{.ReturnDataName}}, err)
 		},

--- a/bridge/templates/template.binary.m
+++ b/bridge/templates/template.binary.m
@@ -3,13 +3,15 @@ classdef Flywheel
     % Flywheel class enables user to communicate with Flywheel platform
     properties
         key     % key - API Key assigned through the Flywheel UI
+        root    % root - Whether or not this client is in management mode
         folder  % folder - folder where the SDK code is located
     end
     methods
-        function obj = Flywheel(apiKey)
+        function obj = Flywheel(apiKey, root)
             % Usage Flywheel(apiKey)
             %  apiKey - API Key assigned for each user through the Flywheel UI
             %          apiKey must be in format <domain>:<API token>
+            %  root - Set to 'true' to indicate that the client should run in manage mode
             C = strsplit(apiKey, ':');
             % Check if key is valid
             if length(C) < 2
@@ -17,6 +19,14 @@ classdef Flywheel
                 throw(ME)
             end
             obj.key = apiKey;
+
+            % Set root mode
+            if exist('root', 'var') && root
+                obj.root = 'true';
+            else
+                obj.root = 'false';
+            end
+
             % Check if JSONio is in path
             if ~exist('jsonread')
                 ME = MException('FlywheelException:JSONio', 'JSONio function jsonsave is not loaded. Please install JSONio and add to path.')
@@ -65,7 +75,7 @@ classdef Flywheel
             opts = struct('replacementStyle','hex');
             {{.ParamDataName}} = jsonwrite({{.ParamDataName}},opts);
             {{end -}}
-            [status,cmdout] = system([obj.folder '/sdk {{.Name}} ' obj.key ' ' {{range .Params}} '''' {{.Name}} ''' '{{end -}}]);
+            [status,cmdout] = system([obj.folder '/sdk {{.Name}} ' obj.key ' ' obj.root ' ' {{range .Params}} '''' {{.Name}} ''' '{{end -}}]);
 
             result = Flywheel.handleJson(status,cmdout);
         end

--- a/bridge/templates/template.go.
+++ b/bridge/templates/template.go.
@@ -25,7 +25,7 @@ type CallResult struct {
 	Data interface{} `json:"data"`
 }
 
-func makeClient(apiKey *C.char) *api.Client {
+func makeClient(apiKey *C.char, root C.int) *api.Client {
 	apiKeyRaw := C.GoString(apiKey)
 
 	// Parse the key into its components, so that we can activate some bridge-only features.
@@ -50,6 +50,11 @@ func makeClient(apiKey *C.char) *api.Client {
 	// No production instance should EVER be on a non-443 port.
 	if port != 443 {
 		options = append(options, api.InsecureNoSSLVerification)
+	}
+
+	// Enable root mode
+	if int(root) == 1 {
+		options = append(options, api.EnableRoot)
 	}
 
 	// Intentionally undocumented option: if ',InsecureUsePlaintext' is appended to the key, use HTTP.
@@ -123,7 +128,7 @@ func TestBridge(name *C.char) *C.char {
 
 {{range .Signatures}}
 //export {{.Name}}
-func {{.Name}}(apiKey *C.char{{range .Params}}, {{.Name}} {{.CgoType}}{{end}}, status *C.int) *C.char {
+func {{.Name}}(apiKey *C.char, root C.int{{range .Params}}, {{.Name}} {{.CgoType}}{{end}}, status *C.int) *C.char {
 	{{range .Params}}{{if or (eq .Type "string") (eq .Type "data")}}{{.Name}}Go := C.GoString({{.Name}})
 	{{end}}{{end}}{{if ne .ParamDataName ""}}
 	var parsed{{.ParamDataName}} {{.ParamDataType}}
@@ -132,7 +137,7 @@ func {{.Name}}(apiKey *C.char{{range .Params}}, {{.Name}} {{.CgoType}}{{end}}, s
 		return format(nil, parseErr, status)
 	}
 	{{end}}
-	{{ $length := .LastResultIndex }}{{range $ind, $val := .Results}}{{.Name}}{{if lt $ind $length}}, {{end}}{{end}} := makeClient(apiKey).{{.Name}}({{ $length := .LastParamIndex }}{{ $ShouldDeref := .ShouldDeref }}{{range $ind, $val := .Params}}{{if eq $val.Type "data"}}{{if $ShouldDeref }}&{{end}}parsed{{end}}{{$val.Name}}{{if eq $val.Type "string"}}Go{{end}}{{if lt $ind $length}}, {{end}}{{end}})
+	{{ $length := .LastResultIndex }}{{range $ind, $val := .Results}}{{.Name}}{{if lt $ind $length}}, {{end}}{{end}} := makeClient(apiKey, root).{{.Name}}({{ $length := .LastParamIndex }}{{ $ShouldDeref := .ShouldDeref }}{{range $ind, $val := .Params}}{{if eq $val.Type "data"}}{{if $ShouldDeref }}&{{end}}parsed{{end}}{{$val.Name}}{{if eq $val.Type "string"}}Go{{end}}{{if lt $ind $length}}, {{end}}{{end}})
 	return format({{.ReturnDataName}}, err, status)
 }
 {{end}}

--- a/bridge/templates/template.m
+++ b/bridge/templates/template.m
@@ -3,12 +3,14 @@ classdef Flywheel
     % Flywheel class enables user to communicate with Flywheel platform
     properties
         key     % key - API Key assigned through the Flywheel UI
+        root    % root - Whether or not this client is in management mode
     end
     methods
-        function obj = Flywheel(apiKey)
+        function obj = Flywheel(apiKey, root)
             % Usage Flywheel(apiKey)
             %  apiKey - API Key assigned for each user through the Flywheel UI
             %          apiKey must be in format <domain>:<API token>
+            %  root - Set to 'true' to indicate that the client should run in manage mode
             C = strsplit(apiKey, ':');
             % Check if key is valid
             if length(C) < 2
@@ -16,6 +18,14 @@ classdef Flywheel
                 throw(ME)
             end
             obj.key = apiKey;
+
+            % Set root mode
+            if exist('root', 'var') && root
+                obj.root = 1;
+            else
+                obj.root = 0;
+            end
+
             % Check if JSONio is in path
             if ~exist('jsonread')
                 ME = MException('FlywheelException:JSONio', 'JSONio function jsonread is not loaded. Please install JSONio and add to path.')
@@ -64,7 +74,7 @@ classdef Flywheel
             opts = struct('replacementStyle','hex');
             {{.ParamDataName}} = jsonwrite({{.ParamDataName}},opts);
             {{end -}}
-            pointer = calllib('flywheelBridge','{{.Name}}',obj.key,{{range .Params}}{{.Name}},{{end -}} statusPtr);
+            pointer = calllib('flywheelBridge','{{.Name}}',obj.key,obj.root,{{range .Params}}{{.Name}},{{end -}} statusPtr);
             result = Flywheel.handleJson(statusPtr,pointer);
         end
         {{end}}

--- a/bridge/templates/template.py
+++ b/bridge/templates/template.py
@@ -39,10 +39,11 @@ class FlywheelException(Exception):
 
 class Flywheel:
 
-    def __init__(self, key):
+    def __init__(self, key, root=False):
         if len(key.split(':')) < 2:
             raise FlywheelException('Invalid API key.')
         self.key = six.b(key)
+        self.root = 1 if root else 0
 
     @staticmethod
     def _handle_return(status, pointer):
@@ -89,7 +90,7 @@ class Flywheel:
         status = ctypes.c_int(-100)
         {{if ne .ParamDataName ""}}{{.ParamDataName}} = json.dumps({{.ParamDataName}})
         {{end -}}
-        pointer = bridge.{{.Name}}(self.key, {{range .Params}}six.b(str({{.Name}})), {{end -}} ctypes.byref(status))
+        pointer = bridge.{{.Name}}(self.key, self.root, {{range .Params}}six.b(str({{.Name}})), {{end -}} ctypes.byref(status))
         return self._handle_return(status, pointer)
     {{end}}
 

--- a/bridge/templates/template.r.cpp
+++ b/bridge/templates/template.r.cpp
@@ -15,7 +15,7 @@ int double_me3(int x) {
 
 {{range .Signatures}}
 // [[Rcpp::export]]
-char* fw_{{.Name}}(char* apiKey{{range .Params}}, {{.CType}} {{.Name}}{{end}}, int* status) {
+char* fw_{{.Name}}(char* apiKey, int root{{range .Params}}, {{.CType}} {{.Name}}{{end}}, int* status) {
 	return {{.Name}}(apiKey{{range .Params}}, {{.Name}}{{end}}, status);
 }
 {{end}}

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -224,10 +224,10 @@ func (t *F) TestCreateProjectInRootMode() {
 	projects, _, err := t.GetAllProjects()
 	t.So(err, ShouldBeNil)
 	// workaround: all-container endpoints skip some fields, single-container does not. this sets up the equality check
-	rProject.Files = nil
-	rProject.Notes = nil
-	rProject.Tags = nil
-	rProject.Info = nil
+	rProject.Files = []*api.File{}
+	rProject.Notes = []*api.Note{}
+	rProject.Tags = []string{}
+	rProject.Info = map[string]interface{}{}
 	t.So(projects, ShouldNotContain, rProject)
 
 	// Should see project as root

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -170,6 +170,72 @@ func (t *F) TestProjectFiles() {
 	t.So(rProject.Files[0].Info, ShouldBeEmpty)
 }
 
+func (t *F) TestCreateProjectInRootMode() {
+	groupId := t.createTestGroup()
+
+	group, _, err := t.GetGroup(groupId)
+	t.So(err, ShouldBeNil)
+
+	// Save user id
+	userId := group.Permissions[0].Id
+
+	// Remove permissions
+	var aerr *api.Error
+	var response *api.ModifiedResponse
+
+	_, err = t.New().Delete("groups/"+groupId+"/permissions/"+userId).Receive(&response, &aerr)
+	err = api.Coalesce(err, aerr)
+	t.So(err, ShouldBeNil)
+
+	group2, _, err := t.GetGroup(groupId)
+	t.So(group2.Permissions, ShouldResemble, []*api.Permission{})
+
+	// Now we should get an error trying to create a new project
+	project := &api.Project{
+		Name:    RandString(),
+		GroupId: groupId,
+	}
+	_, _, err = t.AddProject(project)
+	t.So(err, ShouldNotBeNil)
+	t.So(err.Error(), ShouldEqual, "(403) user not authorized to perform a POST operation on the container.")
+
+	// But we shouldn't get an error in root mode
+	projectId, _, err := t.RootClient.AddProject(project)
+	t.So(err, ShouldBeNil)
+	t.So(projectId, ShouldNotBeNil)
+
+	// Delete the implicit permission from the project
+	_, err = t.New().Delete("projects/"+projectId+"/permissions/"+userId).Receive(&response, &aerr)
+	err = api.Coalesce(err, aerr)
+	t.So(err, ShouldBeNil)
+
+	// Should get 403 error
+	rProject, _, err := t.GetProject(projectId)
+	t.So(rProject, ShouldBeNil)
+	t.So(err, ShouldNotBeNil)
+	t.So(err.Error(), ShouldEqual, "(403) user not authorized to perform a GET operation on the container.")
+
+	// Should be able to retrieve the project as root
+	rProject, _, err = t.RootClient.GetProject(projectId)
+	t.So(err, ShouldBeNil)
+	t.So(rProject, ShouldNotBeNil)
+
+	// Should not see project in list
+	projects, _, err := t.GetAllProjects()
+	t.So(err, ShouldBeNil)
+	// workaround: all-container endpoints skip some fields, single-container does not. this sets up the equality check
+	rProject.Files = nil
+	rProject.Notes = nil
+	rProject.Tags = nil
+	rProject.Info = nil
+	t.So(projects, ShouldNotContain, rProject)
+
+	// Should see project as root
+	projects, _, err = t.RootClient.GetAllProjects()
+	t.So(err, ShouldBeNil)
+	t.So(projects, ShouldContain, rProject)
+}
+
 func (t *F) createTestProject() (string, string) {
 	groupId := t.createTestGroup()
 


### PR DESCRIPTION
Enabled in **go** by passing the `EnableRoot` `ApiKeyClientOption` on client creation

Enabled in **python** by creating client as: `fw = flywheel.Flywheel(api_key, root=True)`

Enabled in **matlab** by creating client as: `fw = Flywheel(apiKey, true);`

@kofalt Could you please try running the matlab test driver on Linux?

Closes #55