### PR TITLE
Add basic mgo interop and tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,6 +138,7 @@ jobs:
                 command: ./bridge/scripts/test-wheel.sh
                 environment:
                   SdkTestKey: "localhost:8080:insecure-key,InsecureUsePlaintext"
+                  SdkTestMongo: "localhost"
                   PYTHONDONTWRITEBYTECODE: "really"
 
             # - run:

--- a/.circleci/prepare-environment.go
+++ b/.circleci/prepare-environment.go
@@ -5,7 +5,7 @@ import (
 	. "log"
 	"time"
 
-	"gopkg.in/mgo.v2"
+	"github.com/globalsign/mgo"
 
 	"flywheel.io/sdk/api"
 )

--- a/api/acquisition.go
+++ b/api/acquisition.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Acquisition struct {
-	Id        string `json:"_id,omitempty"`
-	Name      string `json:"label,omitempty"`
+	Id        string `json:"_id,omitempty" bson:"_id"`
+	Name      string `json:"label,omitempty" bson:"label"`
 	SessionId string `json:"session,omitempty"`
 
 	Timestamp *time.Time `json:"timestamp,omitempty"`

--- a/api/analysis.go
+++ b/api/analysis.go
@@ -30,7 +30,7 @@ type AnalysisFile struct {
 }
 
 type Analysis struct {
-	Id     string              `json:"_id,omitempty"`
+	Id     string              `json:"_id,omitempty" bson:"_id"`
 	Name   string              `json:"label,omitempty"`
 	Parent *ContainerReference `json:"parent,omitempty"`
 
@@ -55,7 +55,7 @@ type Analysis struct {
 }
 
 type AnalysisListItem struct {
-	Id     string              `json:"_id,omitempty"`
+	Id     string              `json:"_id,omitempty" bson:"_id"`
 	Name   string              `json:"label,omitempty"`
 	Parent *ContainerReference `json:"parent,omitempty"`
 

--- a/api/batch.go
+++ b/api/batch.go
@@ -6,7 +6,7 @@ import (
 )
 
 type Batch struct {
-	Id     string `json:"_id,omitempty"`
+	Id     string `json:"_id,omitempty" bson:"_id"`
 	GearId string `json:"gear_id,omitempty"`
 
 	State  JobState `json:"state,omitempty"`
@@ -20,7 +20,7 @@ type Batch struct {
 }
 
 type BatchProposal struct {
-	Id     string                 `json:"_id,omitempty"`
+	Id     string                 `json:"_id,omitempty" bson:"_id"`
 	GearId string                 `json:"gear_id,omitempty"`
 	Config map[string]interface{} `json:"config,omitempty"`
 	State  string                 `json:"state,omitempty"`

--- a/api/collection.go
+++ b/api/collection.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Collection struct {
-	Id          string `json:"_id,omitempty"`
-	Name        string `json:"label,omitempty"`
+	Id          string `json:"_id,omitempty" bson:"_id"`
+	Name        string `json:"label,omitempty" bson:"name"`
 	Curator     string `json:"curator,omitempty"`
 	Description string `json:"description,omitempty"`
 

--- a/api/gear.go
+++ b/api/gear.go
@@ -52,7 +52,7 @@ const (
 )
 
 type GearDoc struct {
-	Id       string       `json:"_id,omitempty"`
+	Id       string       `json:"_id,omitempty" bson:"_id"`
 	Category GearCategory `json:"category,omitempty"`
 
 	Gear   *Gear       `json:"gear,omitempty"`

--- a/api/group.go
+++ b/api/group.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Group struct {
-	Id   string `json:"_id,omitempty"`
-	Name string `json:"label,omitempty"`
+	Id   string `json:"_id,omitempty" bson:"_id"`
+	Name string `json:"label,omitempty" bson:"label"`
 
 	Created  *time.Time `json:"created,omitempty"`
 	Modified *time.Time `json:"modified,omitempty"`

--- a/api/job.go
+++ b/api/job.go
@@ -73,7 +73,7 @@ type JobProfile struct {
 
 type Job struct {
 	Id     string `json:"id,omitempty" bson:"_id"`
-	GearId string `json:"gear_id,omitempty"`
+	GearId string `json:"gear_id,omitempty" bson:"gear_id"`
 
 	State   JobState `json:"state,omitempty"`
 	Attempt int      `json:"attempt,omitempty"`

--- a/api/job.go
+++ b/api/job.go
@@ -67,6 +67,10 @@ const (
 	JobFailure
 )
 
+type JobProfile struct {
+	Elapsed int64 `json:"elapsed, omitempty"`
+}
+
 type Job struct {
 	Id     string `json:"id,omitempty" bson:"_id"`
 	GearId string `json:"gear_id,omitempty"`
@@ -87,6 +91,8 @@ type Job struct {
 
 	Created  *time.Time `json:"created,omitempty"`
 	Modified *time.Time `json:"modified,omitempty"`
+
+	Profile JobProfile `json:"profile,omitempty"`
 }
 
 type JobLogStatement struct {

--- a/api/job.go
+++ b/api/job.go
@@ -68,7 +68,7 @@ const (
 )
 
 type Job struct {
-	Id     string `json:"id,omitempty"`
+	Id     string `json:"id,omitempty" bson:"_id"`
 	GearId string `json:"gear_id,omitempty"`
 
 	State   JobState `json:"state,omitempty"`

--- a/api/project.go
+++ b/api/project.go
@@ -8,8 +8,8 @@ import (
 )
 
 type Project struct {
-	Id          string `json:"_id,omitempty"`
-	Name        string `json:"label,omitempty"`
+	Id          string `json:"_id,omitempty" bson:"_id"`
+	Name        string `json:"label,omitempty" bson:"label"`
 	GroupId     string `json:"group,omitempty"`
 	Description string `json:"description,omitempty"`
 

--- a/api/session.go
+++ b/api/session.go
@@ -8,7 +8,7 @@ import (
 )
 
 type Subject struct {
-	Id   string `json:"_id,omitempty"`
+	Id   string `json:"_id,omitempty" bson:"_id"`
 	Code string `json:"code,omitempty"`
 
 	Firstname string `json:"firstname,omitempty"`
@@ -20,8 +20,8 @@ type Subject struct {
 }
 
 type Session struct {
-	Id        string `json:"_id,omitempty"`
-	Name      string `json:"label,omitempty"`
+	Id        string `json:"_id,omitempty" bson:"_id"`
+	Name      string `json:"label,omitempty" bson:"label"`
 	GroupId   string `json:"group,omitempty"`
 	ProjectId string `json:"project,omitempty"`
 

--- a/api/user.go
+++ b/api/user.go
@@ -17,7 +17,7 @@ type Key struct {
 
 // User represents a single user.
 type User struct {
-	Id        string `json:"_id,omitempty"`
+	Id        string `json:"_id,omitempty" bson:"_id"`
 	Email     string `json:"email,omitempty"`
 	Firstname string `json:"firstname,omitempty"`
 	Lastname  string `json:"lastname,omitempty"`

--- a/glide.lock
+++ b/glide.lock
@@ -14,9 +14,9 @@ imports:
   version: 2df9a531813370438a4d79bfc33e21f58063ed87
 - name: github.com/spf13/pflag
   version: e57e3eeb33f795204c1ca35f56c44f83227c6e66
-- name: gopkg.in/mgo.v2
-  version: 3f83fa5005286a7fe593b055f0d7771a7dce4655
-  repo: https://github.com/go-mgo/mgo
+- name: github.com/globalsign/mgo
+  version: baa28fcb8e7d5dfab92026c0920cb6c9ae72faa2
+  repo: https://github.com/globalsign/mgo
 testImports:
 - name: github.com/smartystreets/assertions
   version: c9ee7d9e9a2aeec0bee7c4a516f3e0ad7cb7e558

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,12 +1,17 @@
 package: flywheel.io/sdk
-homepage: https://github.com/flywheel-io/core-sdk
+
+homepage: https://github.com/flywheel-io/sdk
 license: MIT
+
 owners:
 - name:  Nathaniel Kofalt
   email: nathaniel.kofalt@gmail.com
+
 import:
-- package: gopkg.in/mgo.v2
-  repo:    https://github.com/go-mgo/mgo
-  version: v2
+
+- package: github.com/globalsign/mgo
+  repo:    https://github.com/globalsign/mgo
+  version: master
+
 - package: github.com/smartystreets/gunit
   repo:    https://github.com/kofalt/gunit

--- a/readme.md
+++ b/readme.md
@@ -29,6 +29,7 @@ circleci build
 If you want to test manually, you can configure the test suite with these environment variables:
 
 * `SdkTestKey`: Set this to an API key. Defaults to `localhost:8443:change-me`.
+* `SdkTestMongo`: Set this to a mongo connection string. If not set, database tests are skipped.
 * `SdkTestDebug`: Setting this to any value will cause each test to print an HTTP/1.1 representation of each request. Best used to debug a single failing test.
 
 To run the integration test suite against a running API:

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -49,9 +49,6 @@ func (t *F) TestBatch() {
 	t.So(err, ShouldBeNil)
 	t.So(batches, ShouldContain, rBatch)
 
-	JobQueue.Lock()
-	defer JobQueue.Unlock()
-
 	// Start
 	jobs, _, err := t.StartBatch(proposal.Id)
 	t.So(err, ShouldBeNil)

--- a/tests/batch_test.go
+++ b/tests/batch_test.go
@@ -49,6 +49,9 @@ func (t *F) TestBatch() {
 	t.So(err, ShouldBeNil)
 	t.So(batches, ShouldContain, rBatch)
 
+	JobQueue.Lock()
+	defer JobQueue.Unlock()
+
 	// Start
 	jobs, _, err := t.StartBatch(proposal.Id)
 	t.So(err, ShouldBeNil)

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -1,0 +1,191 @@
+package tests
+
+import (
+	"encoding/hex"
+	"time"
+
+	"github.com/globalsign/mgo"
+	"github.com/globalsign/mgo/bson"
+
+	. "github.com/smartystreets/assertions"
+
+	"flywheel.io/sdk/api"
+)
+
+func (t *F) TestDbAccess() {
+	// t.SkipNow is not provided; for now just silently succeed.
+	if t.MongoString == "" {
+		return
+	}
+
+	// Connect
+	m, err := mgo.DialWithTimeout(t.MongoString, time.Duration(3*time.Second))
+	t.So(err, ShouldBeNil)
+	defer m.Close()
+	m.SetSafe(&mgo.Safe{}) //durability
+
+	// Hierarchy
+	groupId, projectId, sessionId, acquisitionId := t.createTestAcquisition()
+	gearId := t.createTestGear()
+
+	//
+	// Check deserialization
+	//
+
+	var group api.Group
+	err = m.DB("scitran").C("groups").Find(t.createStringIdQuery(groupId)).One(&group)
+	t.So(err, ShouldBeNil)
+	t.So(group.Id, ShouldEqual, groupId)
+
+	var project api.Project
+	err = m.DB("scitran").C("projects").Find(t.createIdQuery(projectId)).One(&project)
+	t.So(err, ShouldBeNil)
+	t.checkBinaryId(project.Id, projectId)
+
+	var session api.Session
+	err = m.DB("scitran").C("sessions").Find(t.createIdQuery(sessionId)).One(&session)
+	t.So(err, ShouldBeNil)
+	t.checkBinaryId(session.Id, sessionId)
+
+	var acquisition api.Acquisition
+	err = m.DB("scitran").C("acquisitions").Find(t.createIdQuery(acquisitionId)).One(&acquisition)
+	t.So(err, ShouldBeNil)
+	t.checkBinaryId(acquisition.Id, acquisitionId)
+
+	rUser, _, err := t.GetCurrentUser()
+	t.So(err, ShouldBeNil)
+
+	var user api.User
+	err = m.DB("scitran").C("users").Find(t.createStringIdQuery(rUser.Id)).One(&user)
+	t.So(err, ShouldBeNil)
+
+	//
+	// Compare to same values in API
+	//
+
+	savedGroup, _, err := t.GetGroup(groupId)
+	t.So(err, ShouldBeNil)
+	t.So(savedGroup.Name, ShouldEqual, group.Name)
+	t.So(*savedGroup.Created, ShouldBeSameTimeAs, *group.Created)
+	t.So(*savedGroup.Modified, ShouldBeSameTimeAs, *group.Modified)
+
+	rProject, _, err := t.GetProject(projectId)
+	t.So(err, ShouldBeNil)
+	t.So(rProject.Id, ShouldEqual, projectId)
+	t.So(rProject.Name, ShouldEqual, project.Name)
+	t.So(rProject.Description, ShouldEqual, project.Description)
+	t.So(rProject.Info, ShouldContainKey, "some-key")
+	t.So(rProject.Info["some-key"], ShouldEqual, 37)
+	t.So(*rProject.Created, ShouldBeSameTimeAs, *project.Created)
+	t.So(*rProject.Modified, ShouldBeSameTimeAs, *project.Modified)
+
+	rSession, _, err := t.GetSession(sessionId)
+	t.So(err, ShouldBeNil)
+	t.So(rSession.Id, ShouldEqual, sessionId)
+	t.So(rSession.Name, ShouldEqual, session.Name)
+	t.So(rSession.Info, ShouldContainKey, "some-key")
+	t.So(rSession.Info["some-key"], ShouldEqual, 37)
+	t.So(*rSession.Created, ShouldBeSameTimeAs, *session.Created)
+	t.So(*rSession.Modified, ShouldBeSameTimeAs, *session.Modified)
+	t.So(*rSession.Subject, ShouldNotBeNil)
+	t.So(rSession.Subject.Id, ShouldNotBeEmpty)
+	t.So(rSession.Subject.Firstname, ShouldResemble, session.Subject.Firstname)
+
+	rAcquisition, _, err := t.GetAcquisition(acquisitionId)
+	t.So(err, ShouldBeNil)
+	t.So(rAcquisition.Id, ShouldEqual, acquisitionId)
+	t.So(rAcquisition.Name, ShouldEqual, acquisition.Name)
+	t.So(*rAcquisition.Created, ShouldBeSameTimeAs, *acquisition.Created)
+	t.So(*rAcquisition.Modified, ShouldBeSameTimeAs, *acquisition.Modified)
+
+	t.So(user.Id, ShouldEqual, rUser.Id)
+	t.So(user.Email, ShouldEqual, rUser.Email)
+	t.So(user.Firstname, ShouldEqual, rUser.Firstname)
+	t.So(user.Lastname, ShouldEqual, rUser.Lastname)
+	t.So(*user.Created, ShouldBeSameTimeAs, *rUser.Created)
+	t.So(*user.Modified, ShouldBeSameTimeAs, *rUser.Modified)
+
+	//
+	// Check jobs
+	//
+
+	src := UploadSourceFromString("yeats.txt", "A gaze blank and pitiless as the sun,")
+	progress, resultChan := t.UploadToSession(sessionId, src)
+	t.checkProgressChanEndsWith(progress, 37)
+	t.So(<-resultChan, ShouldBeNil)
+
+	filereference := &api.FileReference{
+		Id:   sessionId,
+		Type: "session",
+		Name: "yeats.txt",
+	}
+
+	JobQueue.Lock()
+	defer JobQueue.Unlock()
+
+	tag := RandString()
+	sendJob := &api.Job{
+		GearId: gearId,
+		Inputs: map[string]interface{}{
+			"any-file": filereference,
+		},
+		Tags: []string{tag},
+	}
+	jobId, _, err := t.AddJob(sendJob)
+	t.So(err, ShouldBeNil)
+
+	var job api.Job
+	err = m.DB("scitran").C("jobs").Find(t.createIdQuery(jobId)).One(&job)
+	t.So(err, ShouldBeNil)
+	t.checkBinaryId(job.Id, jobId)
+
+	rJob, _, err := t.GetJob(jobId)
+	t.So(err, ShouldBeNil)
+	t.So(rJob.GearId, ShouldEqual, gearId)
+	t.So(rJob.State, ShouldEqual, api.Pending)
+	t.So(rJob.Attempt, ShouldEqual, 1)
+	t.So(rJob.Origin, ShouldNotBeNil)
+	t.So(rJob.Origin.Type, ShouldEqual, "user")
+	t.So(rJob.Origin.Id, ShouldNotBeEmpty)
+	t.So(rJob.Tags, ShouldContain, tag)
+	t.So(*rJob.Created, ShouldBeSameTimeAs, *job.Created)
+	t.So(*rJob.Modified, ShouldBeSameTimeAs, *job.Modified)
+
+	var gear api.GearDoc
+	err = m.DB("scitran").C("gears").Find(t.createIdQuery(gearId)).One(&gear)
+	t.So(err, ShouldBeNil)
+	t.checkBinaryId(gear.Id, gearId)
+
+	rGear, _, err := t.GetGear(gearId)
+	t.So(err, ShouldBeNil)
+	t.So(rGear.Gear.Name, ShouldEqual, gear.Gear.Name)
+	t.So(*rGear.Created, ShouldBeSameTimeAs, *gear.Created)
+	t.So(*rGear.Modified, ShouldBeSameTimeAs, *gear.Modified)
+
+}
+
+// Convert a dumb binary string into hex, and check that it's DB-ID-ish.
+func (t *F) checkBinaryId(binaryString, compare string) {
+	// If the string is empty, we're missing a bson annotation
+	t.So(binaryString, ShouldNotBeEmpty)
+
+	// Initial data should be binary
+	t.So(binaryString, ShouldNotMatchRegex, idRegex)
+
+	// Encode the garbage into something useful
+	id := hex.EncodeToString([]byte(binaryString))
+
+	// Now it should be DB-ID-ish.
+	t.So(id, ShouldMatchRegex, idRegex)
+
+	// Result should be as expected
+	t.So(id, ShouldEqual, compare)
+}
+
+func (t *F) createIdQuery(id string) map[string]interface{} {
+	return map[string]interface{}{"_id": bson.ObjectIdHex(id)}
+}
+
+func (t *F) createStringIdQuery(id string) map[string]interface{} {
+	return map[string]interface{}{"_id": id}
+}

--- a/tests/database_test.go
+++ b/tests/database_test.go
@@ -120,9 +120,6 @@ func (t *F) TestDbAccess() {
 		Name: "yeats.txt",
 	}
 
-	JobQueue.Lock()
-	defer JobQueue.Unlock()
-
 	tag := RandString()
 	sendJob := &api.Job{
 		GearId: gearId,

--- a/tests/group_test.go
+++ b/tests/group_test.go
@@ -71,8 +71,9 @@ func (t *F) TestGroups() {
 
 func (t *F) createTestGroup() string {
 	groupId := RandStringLower() // conform to group ID regex
+	groupName := RandString()
 
-	_, _, err := t.AddGroup(&api.Group{Id: groupId})
+	_, _, err := t.AddGroup(&api.Group{Id: groupId, Name: groupName})
 	t.So(err, ShouldBeNil)
 
 	return groupId

--- a/tests/job_test.go
+++ b/tests/job_test.go
@@ -1,12 +1,15 @@
 package tests
 
 import (
+	"sync"
 	"time"
 
 	. "github.com/smartystreets/assertions"
 
 	"flywheel.io/sdk/api"
 )
+
+var JobQueue sync.Mutex
 
 func (t *F) TestJobs() {
 	_, _, _, acquisitionId := t.createTestAcquisition()
@@ -34,6 +37,9 @@ func (t *F) TestJobs() {
 
 		Tags: []string{tag},
 	}
+
+	JobQueue.Lock()
+	defer JobQueue.Unlock()
 
 	// Add
 	jobId, _, err := t.AddJob(job)

--- a/tests/job_test.go
+++ b/tests/job_test.go
@@ -1,15 +1,12 @@
 package tests
 
 import (
-	"sync"
 	"time"
 
 	. "github.com/smartystreets/assertions"
 
 	"flywheel.io/sdk/api"
 )
-
-var JobQueue sync.Mutex
 
 func (t *F) TestJobs() {
 	_, _, _, acquisitionId := t.createTestAcquisition()
@@ -37,9 +34,6 @@ func (t *F) TestJobs() {
 
 		Tags: []string{tag},
 	}
-
-	JobQueue.Lock()
-	defer JobQueue.Unlock()
 
 	// Add
 	jobId, _, err := t.AddJob(job)

--- a/tests/project_test.go
+++ b/tests/project_test.go
@@ -278,8 +278,12 @@ func (t *F) createTestProject() (string, string) {
 	groupId := t.createTestGroup()
 
 	project := &api.Project{
-		Name:    RandString(),
-		GroupId: groupId,
+		Name:        RandString(),
+		GroupId:     groupId,
+		Description: "This is a description",
+		Info: map[string]interface{}{
+			"some-key": 37,
+		},
 	}
 	projectId, _, err := t.AddProject(project)
 	t.So(err, ShouldBeNil)

--- a/tests/session_test.go
+++ b/tests/session_test.go
@@ -230,6 +230,19 @@ func (t *F) createTestSession() (string, string, string) {
 	session := &api.Session{
 		Name:      sessionName,
 		ProjectId: projectId,
+		Info: map[string]interface{}{
+			"some-key": 37,
+		},
+		Subject: &api.Subject{
+			Code:      RandStringLower(),
+			Firstname: RandString(),
+			Lastname:  RandString(),
+			Sex:       "other",
+			Age:       56,
+			Info: map[string]interface{}{
+				"some-subject-key": 37,
+			},
+		},
 	}
 	sessionId, _, err := t.AddSession(session)
 	t.So(err, ShouldBeNil)


### PR DESCRIPTION
This adds the basic capability to interact with the database using the SDK structs, which is convenient for some backend scripts. Along the way it looks like there is a newer fork of the mgo library, which I switched to.

The tests are not exhaustive, but all the structs are updated and the main hierarchy + jobs are covered.